### PR TITLE
TextFlow: fix length calculation in case text starts with linebreak

### DIFF
--- a/TextFlow.hpp
+++ b/TextFlow.hpp
@@ -78,6 +78,8 @@ namespace TextFlow {
                 m_suffix = false;
                 auto width = m_column.m_width-indent();
                 m_end = m_pos;
+                if(!line().empty() && line()[m_pos] == '\n')
+                    ++m_end;
                 while( m_end < line().size() && line()[m_end] != '\n' )
                     ++m_end;
 

--- a/TextFlow_Tests.cpp
+++ b/TextFlow_Tests.cpp
@@ -279,6 +279,22 @@ TEST_CASE( "another long string" ) {
         "  convallis posuere, libero nisi ultricies orci, nec lobortis." );
 }
 
+TEST_CASE( "message with linebreak at start" )
+{
+    const auto message = std::string(
+        "\nthis is a message starting with linebreak"
+    );
+
+    auto col = Column( message )
+        .width(79)
+        .indent(2);
+
+    REQUIRE(col.toString() ==
+        "  \n"
+        "this is a message starting with linebreak"
+    );
+}
+
 std::mt19937 rng;
 std::uniform_int_distribution<std::mt19937::result_type> wordCharGenerator(33,126);
 std::uniform_int_distribution<std::mt19937::result_type> wsGenerator(0, 11);


### PR DESCRIPTION
original fix by @Danielhu229
catchorg/Catch2#1470